### PR TITLE
feat: add synth image for PET example

### DIFF
--- a/data/python/synth/Dockerfile
+++ b/data/python/synth/Dockerfile
@@ -1,0 +1,18 @@
+FROM python:3.10
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update -yqq && \
+    apt-get dist-upgrade -yqq && \
+    apt-get install -yqq git
+
+COPY requirements.txt /tmp/requirements.txt
+
+RUN python3 -m pip install --upgrade pip
+RUN pip3 install -r /tmp/requirements.txt
+
+# python-sdk-patterns 0.6.5 pins opendp to <0.13.0, but smartnoise-synth
+# requires opendp >=0.14 internally. Install patterns with --no-deps so
+# its opendp pin does not override the version smartnoise-synth pulls.
+RUN pip3 install git+https://github.com/PrivateAIM/python-sdk.git@0.6.0
+RUN pip3 install --no-deps git+https://github.com/PrivateAIM/python-sdk-patterns.git@0.6.5

--- a/data/python/synth/README.md
+++ b/data/python/synth/README.md
@@ -1,0 +1,13 @@
+# Python synthetic-data image
+
+Prebuilt Python 3 image for generating and auditing privacy-preserving
+synthetic data in federated analyses. Includes:
+
+- [smartnoise-synth](https://github.com/opendp/smartnoise-sdk):
+  differentially private synthesizers (MWEM-PGM, AIM, DP-CTGAN), built
+  on OpenDP and uses pytorch as transitive dependency
+- [anonymeter](https://github.com/statice/anonymeter): privacy risk
+  evaluation for synthetic data (singling-out, linkability, inference
+  attacks)
+- pandas, numpy, scikit-learn
+

--- a/data/python/synth/requirements.txt
+++ b/data/python/synth/requirements.txt
@@ -1,0 +1,8 @@
+pandas == 2.2.2
+numpy == 1.26.4
+scikit-learn == 1.5.2
+smartnoise-synth == 1.0.8
+anonymeter == 1.0.0
+httpx == 0.27.0
+fastapi == 0.110.0
+uvicorn == 0.27.1


### PR DESCRIPTION
Adds data/python/synth/ for DP synthetic data generation. Used by the upcoming pet-examples repo.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a prebuilt Python environment for generating and auditing privacy-preserving synthetic data, featuring integrated tools for differential privacy synthesis, privacy risk evaluation, and data analysis.

* **Documentation**
  * Added documentation describing the environment, included tools, and their capabilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PrivateAIM/master-images/pull/282?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->